### PR TITLE
Bug: multiplus doesn't produce statistics after programming

### DIFF
--- a/deployment/jobs/hab-ve-mk3.hcl
+++ b/deployment/jobs/hab-ve-mk3.hcl
@@ -11,7 +11,7 @@ job "hab-ve-mk3" {
       driver = "docker"
 
       config {
-        image = "registry.hab.mju.io/hab-ve-mk3:0.1.0-build4"
+        image = "registry.hab.mju.io/hab-ve-mk3:0.2.0-build2"
         devices = [
           {
             host_path = "/dev/serial/by-id/usb-VictronEnergy_MK3-USB_Interface_HQ19125YEZ6-if00-port0"

--- a/hab-ve-mk3/Cargo.lock
+++ b/hab-ve-mk3/Cargo.lock
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "hab-ve-mk3"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",

--- a/hab-ve-mk3/Cargo.toml
+++ b/hab-ve-mk3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hab-ve-mk3"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
After programming with the Victron software, the multiplus enters a mode where it just sends 0xFF bytes, rather than version frames as it does normally at startup.

Added an explicit request for a version frame at program startup to ensure that the version/statistics ping-pong cycle always starts up.