### PR TITLE
deploy unifi container to manage wifi aps

### DIFF
--- a/deployment/jobs/unifi.hcl
+++ b/deployment/jobs/unifi.hcl
@@ -1,0 +1,60 @@
+job "unifi" {
+    region = "hab"
+    datacenters = ["hab"]
+
+    type = "service"
+
+    group "unifi" {
+        network {
+            mode = "host"
+            port "web_admin" {
+                static = 8443
+            }
+            port "stun" {
+                static = 3478
+            }
+            port "discovery" {
+                static = 10001
+            }
+            port "device_comms" {
+                static = 8080
+            }
+        }
+
+        volume "unifi_volume" {
+            type = "host"
+            source = "unifi"
+        }
+
+        task "controller" {
+            driver = "docker"
+
+            config {
+                image = "linuxserver/unifi-controller:7.4.162"
+                ports = [
+                    "web_admin",
+                    "stun",
+                    "discovery",
+                    "device_comms"
+                ]
+            }
+
+            volume_mount {
+                volume = "unifi_volume"
+                destination = "/config"
+            }
+
+            resources {
+                cpu = 1024
+                memory = 1024
+            }
+
+            env {
+                PUID = 1000
+                PGID = 1000
+                TZ = "America/Los_Angeles"
+            }
+        }
+    }
+}
+

--- a/infrastructure/playbooks/roles/hab-server/files/etc/nomad.d/nomad.hcl
+++ b/infrastructure/playbooks/roles/hab-server/files/etc/nomad.d/nomad.hcl
@@ -13,6 +13,10 @@ server {
 client {
   enabled = true
   servers = ["127.0.0.1"]
+
+  host_volume "unifi" {
+    path = "/volumes/unifi"
+  }
 }
 
 ui {

--- a/infrastructure/playbooks/roles/hab-server/tasks/main.yaml
+++ b/infrastructure/playbooks/roles/hab-server/tasks/main.yaml
@@ -163,6 +163,16 @@
   loop:
     - nomad
 
+# Create nomad host volumes
+
+- name: Create nomad host volumes
+  ansible.builtin.file:
+    name: "{{item}}"
+    mode: "0770"
+    state: directory
+  loop:
+    - /volumes/unifi
+
 # Configure the Hashicorp services
 
 - name: Configure Hashicorp services


### PR DESCRIPTION
Deploys linuxserver/unifi-controller:7.4.162.

The newer controller version completely changes how guest networks work, so the guest network has been temporarily deactivated to be fixed later.